### PR TITLE
Feat/change name of skill options

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
 
-import { EffectsContext, HPContext } from '../App';
+import { EffectsContext, HPContext, HumanityContext, StatsContext } from '../App';
 import rolesJson from '../data/roles.json';
-import { Effects, Stats } from '../types/types';
+import { Stats } from '../types/types';
 import DropdownCell from '../utils/DropdownCell';
 import SimpleEditableTextCell from '../utils/SimpleEditableTextCell';
 import {
@@ -20,16 +20,18 @@ type ProfileProps = {
   role: string;
   setRole: (value: string) => void;
   healthPoints: number;
-  humanity: number;
-  stats: Stats;
 };
 
 const allRoles = Object.keys(rolesJson);
 
-const Profile = ({ name, setName, role, setRole, healthPoints, humanity, stats }: ProfileProps) => {
+// COMPONENT START
+const Profile = ({ name, setName, role, setRole, healthPoints }: ProfileProps) => {
   const { HP, setHP } = useContext(HPContext);
   const { currentEffects, setCurrentEffects } = useContext(EffectsContext);
+  const { humanity, setHumanity } = useContext(HumanityContext);
+  const { stats, setStats } = useContext(StatsContext);
 
+  // HEAL METHOD
   const heal = (stats: Stats, HP: number, setHP: (newHP: number) => void) => {
     const HPChangeInput = document.querySelector('#HPChangeInput');
     const HPMax = calculateHPMax(stats);
@@ -59,6 +61,7 @@ const Profile = ({ name, setName, role, setRole, healthPoints, humanity, stats }
     HPChangeInput.value = null;
   };
 
+  // TAKE DAMAGE METHOD
   const takeDamage = (HP: number, setHP: (newHP: number) => void) => {
     const HPChangeInput = document.querySelector('#HPChangeInput');
     let HPChange = HPChangeInput.value;
@@ -87,6 +90,63 @@ const Profile = ({ name, setName, role, setRole, healthPoints, humanity, stats }
     HPChangeInput.value = null;
   };
 
+  // INCREMENT HUMANITY METHOD
+  const incrementHumanity = (
+    humanity: number,
+    setHumanity: (newHumanity: number) => void,
+    stats: Stats,
+    setStats: (stats: Stats) => void,
+  ) => {
+    const humanityChangeInput = document.querySelector('#HumanityChangeInput');
+    let humanityChange = humanityChangeInput.value;
+    if (humanityChange == '') {
+      humanityChange = 1;
+    }
+    humanityChange = parseInt(humanityChange);
+
+    let success = false;
+    const startHumanityModulusTen = humanity % 10;
+
+    if (startHumanityModulusTen == 9) {
+      let newStats = { ...stats };
+      newStats['EMP'] += 1;
+      setStats(newStats);
+    }
+    setHumanity(humanity + humanityChange);
+    success = true;
+    return success;
+  };
+
+  // DECREMENT HUMANITY METHOD
+  const decrementHumanity = (
+    humanity: number,
+    setHumanity: (newHumanity: number) => void,
+    stats: Stats,
+    setStats: (stats: Stats) => void,
+  ) => {
+    const humanityChangeInput = document.querySelector('#HumanityChangeInput');
+    let humanityChange = humanityChangeInput.value;
+    if (humanityChange == '') {
+      humanityChange = 1;
+    }
+    humanityChange = parseInt(humanityChange);
+
+    let success = false;
+    const startHumanityModulusTen = humanity % 10;
+
+    if (humanity > 0 && startHumanityModulusTen == 0) {
+      let newStats = { ...stats };
+      newStats['EMP'] -= 1;
+      setStats(newStats);
+    }
+    if (humanity > 0) {
+      setHumanity(humanity - humanityChange);
+      success = true;
+    }
+    return success;
+  };
+
+  // COMPONENT BODY
   return (
     <div className="flex gap-1">
       <div className="flex box">
@@ -120,7 +180,6 @@ const Profile = ({ name, setName, role, setRole, healthPoints, humanity, stats }
           <div>Health Points (HP)</div>
         </div>
         <div className="flex flex-col justify-center items-center ml-3">
-          {/* these should probably be green and red but ¯\_(ツ)_/¯ how fill? stroke??*/}
           <p
             className="health-button text-heal-green border-heal-green"
             onClick={e => {
@@ -152,6 +211,33 @@ const Profile = ({ name, setName, role, setRole, healthPoints, humanity, stats }
       <div className="box flex flex-col justify-center items-center">
         <div className="text-2xl">{humanity}</div>
         <div>Humanity (HUM)</div>
+      </div>
+      <div className="flex flex-col justify-center items-center ml-3">
+        <p
+          className="health-button text-heal-green border-heal-green"
+          onClick={e => {
+            e.preventDefault();
+            incrementHumanity(humanity, setHumanity, stats, setStats);
+          }}
+        >
+          ADD
+        </p>
+        {/* don't allow negative input */}
+        <input
+          className="box w-20 h-10"
+          type="number"
+          id="HumanityChangeInput"
+          min={0}
+        ></input>
+        <p
+          className="health-button text-damage-red border-damage-red"
+          onClick={e => {
+            e.preventDefault();
+            decrementHumanity(humanity, setHumanity, stats, setStats);
+          }}
+        >
+          REMOVE
+        </p>
       </div>
     </div>
   );

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -131,19 +131,23 @@ const Profile = ({ name, setName, role, setRole, healthPoints }: ProfileProps) =
     }
     humanityChange = parseInt(humanityChange);
 
-    let success = false;
     const startHumanityModulusTen = humanity % 10;
+    let success = true;
 
-    if (humanity > 0 && startHumanityModulusTen == 0) {
-      let newStats = { ...stats };
-      newStats['EMP'] -= 1;
-      setStats(newStats);
+    while (humanityChange > 0 && success == true) {
+      success = false;
+      if (humanity > 0 && startHumanityModulusTen == 0) {
+        let newStats = { ...stats };
+        newStats['EMP'] -= 1;
+        setStats(newStats);
+      }
+      if (humanity > 0) {
+        setHumanity(humanity - 1);
+        humanity -= 1;
+        success = true;
+      }
+      humanityChange -= 1;
     }
-    if (humanity > 0) {
-      setHumanity(humanity - humanityChange);
-      success = true;
-    }
-    return success;
   };
 
   // COMPONENT BODY

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -97,6 +97,7 @@ const Profile = ({ name, setName, role, setRole, healthPoints, humanity, stats }
         <div className="px-2 flex gap-2 items-center">
           <div>Name:</div>
           <SimpleEditableTextCell
+            className="rounded border"
             value={name}
             onChange={e => setName(e.target.value)}
           />

--- a/src/components/SingleSkillTypeTable.tsx
+++ b/src/components/SingleSkillTypeTable.tsx
@@ -54,6 +54,8 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
   // If you activate this, it moves the box to the bottom of the list of options.
   // It's activated every time you press a key so you basically can't change anything unless it's already at the bottom of the list
   // need to use onBlur or onKeyDown instead of onChange? But then how does the text actually change?
+
+  // Change the data structure so that the options have a numerical indetifier to use as a key, and a name property?
   const setOptionName = (
     target: any,
     skillName: string,

--- a/src/components/SingleSkillTypeTable.tsx
+++ b/src/components/SingleSkillTypeTable.tsx
@@ -5,7 +5,6 @@ import skillsJson from '../data/skills.json';
 import { SkillsType } from '../types/types';
 import IncrementDecrementSkill from '../utils/IncrementDecrementSkill';
 import SimpleEditableTextCell from '../utils/SimpleEditableTextCell';
-import Skills from './Skills';
 
 type SingleSkillTypeTableProps = {
   tableSkillType: string;
@@ -32,29 +31,29 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
   ) => {
     const newSkills = { ...currentSkills };
 
+    // This isn't going to work anymore when you can change the names of the options.
     const MAX_SKILL_POINTS = 6;
     let n = 1;
     let success = false;
-    while (success == false && n < MAX_SKILL_POINTS) {
+
+    while (success == false && n <= MAX_SKILL_POINTS && skillName != 'Martial Arts') {
       const optionExists =
-        newSkills[skillName]['options'][`newOption${n}`] || newSkills[skillName]['options'][`newOption${n}`] == 0;
+        newSkills[skillName]['options'][n]['name'] && newSkills[skillName]['options'][n]['name'] != '';
 
       if (optionExists) {
         n += 1;
         continue;
       } else {
+        newSkills[skillName]['options'][n]['name'] = 'New Option';
+        setSkills(newSkills);
         success = true;
       }
     }
-
-    newSkills[skillName]['options'][`newOption${n}`] = 0;
-    setSkills(newSkills);
   };
 
   // If you activate this, it moves the box to the bottom of the list of options.
   // It's activated every time you press a key so you basically can't change anything unless it's already at the bottom of the list
   // need to use onBlur or onKeyDown instead of onChange? But then how does the text actually change?
-
   // Change the data structure so that the options have a numerical indetifier to use as a key, and a name property?
   const setOptionName = (
     target: any,
@@ -62,15 +61,15 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     currentSkills: SkillsType,
     setCurrentSkills: (skills: SkillsType) => void,
   ) => {
-    const oldName = target.dataset.originalvalue;
-    const newName = target.value;
-    if (oldName === newName) {
-      return;
-    }
-    const newSkills = { ...currentSkills };
-    newSkills[skillName]['options'][newName] = newSkills[skillName]['options'][oldName];
-    delete newSkills[skillName]['options'][oldName];
-    setCurrentSkills(newSkills);
+    // const oldName = target.dataset.originalvalue;
+    // const newName = target.value;
+    // if (oldName === newName) {
+    //   return;
+    // }
+    // const newSkills = { ...currentSkills };
+    // newSkills[skillName]['options'][newName] = newSkills[skillName]['options'][oldName];
+    // delete newSkills[skillName]['options'][oldName];
+    // setCurrentSkills(newSkills);
   };
 
   return (
@@ -124,9 +123,18 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
 
             const options = [];
             if (hasOptions) {
-              Object.entries(currentSkills[skillName]['options']).forEach(([optionName, level]) => {
+              Object.entries(currentSkills[skillName]['options']).map(option => {
+                const optionID = option[0];
+                const optionName = option[1]['name'];
+                const optionLevel = option[1]['level'];
+
+                let style = 'option-tr hidden';
+                if (optionName != '') {
+                  style = 'option-tr inline';
+                }
+
                 options.push(
-                  <tr className="option-tr">
+                  <tr className={style}>
                     <td>
                       <SimpleEditableTextCell
                         value={optionName}
@@ -135,7 +143,7 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
                         }}
                       />
                     </td>
-                    <td>{level}</td>
+                    <td>{optionLevel}</td>
                   </tr>,
                 );
               });

--- a/src/components/SingleSkillTypeTable.tsx
+++ b/src/components/SingleSkillTypeTable.tsx
@@ -58,18 +58,15 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
   const setOptionName = (
     target: any,
     skillName: string,
+    optionID: number,
     currentSkills: SkillsType,
     setCurrentSkills: (skills: SkillsType) => void,
   ) => {
-    // const oldName = target.dataset.originalvalue;
-    // const newName = target.value;
-    // if (oldName === newName) {
-    //   return;
-    // }
-    // const newSkills = { ...currentSkills };
-    // newSkills[skillName]['options'][newName] = newSkills[skillName]['options'][oldName];
-    // delete newSkills[skillName]['options'][oldName];
-    // setCurrentSkills(newSkills);
+    const newName = target.value;
+    const newSkills = { ...currentSkills };
+
+    newSkills[skillName]['options'][optionID]['name'] = newName;
+    setCurrentSkills(newSkills);
   };
 
   return (
@@ -139,7 +136,7 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
                       <SimpleEditableTextCell
                         value={optionName}
                         onChange={e => {
-                          setOptionName(e.target, skillName, currentSkills, setCurrentSkills);
+                          setOptionName(e.target, skillName, optionID, currentSkills, setCurrentSkills);
                         }}
                       />
                     </td>

--- a/src/components/SingleSkillTypeTable.tsx
+++ b/src/components/SingleSkillTypeTable.tsx
@@ -2,8 +2,10 @@ import { useContext } from 'react';
 
 import { SkillsContext } from '../App';
 import skillsJson from '../data/skills.json';
-import { Skills } from '../types/types';
+import { SkillsType } from '../types/types';
 import IncrementDecrementSkill from '../utils/IncrementDecrementSkill';
+import SimpleEditableTextCell from '../utils/SimpleEditableTextCell';
+import Skills from './Skills';
 
 type SingleSkillTypeTableProps = {
   tableSkillType: string;
@@ -23,7 +25,11 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     }
   }
 
-  const addNewOption = (currentSkills: Skills, setSkills: (currentSkills: Skills) => void, skillName: string) => {
+  const addNewOption = (
+    currentSkills: SkillsType,
+    setSkills: (currentSkills: SkillsType) => void,
+    skillName: string,
+  ) => {
     const newSkills = { ...currentSkills };
 
     const MAX_SKILL_POINTS = 6;
@@ -43,6 +49,26 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
 
     newSkills[skillName]['options'][`newOption${n}`] = 0;
     setSkills(newSkills);
+  };
+
+  // If you activate this, it moves the box to the bottom of the list of options.
+  // It's activated every time you press a key so you basically can't change anything unless it's already at the bottom of the list
+  // need to use onBlur or onKeyDown instead of onChange? But then how does the text actually change?
+  const setOptionName = (
+    target: any,
+    skillName: string,
+    currentSkills: SkillsType,
+    setCurrentSkills: (skills: SkillsType) => void,
+  ) => {
+    const oldName = target.dataset.originalvalue;
+    const newName = target.value;
+    if (oldName === newName) {
+      return;
+    }
+    const newSkills = { ...currentSkills };
+    newSkills[skillName]['options'][newName] = newSkills[skillName]['options'][oldName];
+    delete newSkills[skillName]['options'][oldName];
+    setCurrentSkills(newSkills);
   };
 
   return (
@@ -99,7 +125,14 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
               Object.entries(currentSkills[skillName]['options']).forEach(([optionName, level]) => {
                 options.push(
                   <tr className="option-tr">
-                    <td>{optionName}</td>
+                    <td>
+                      <SimpleEditableTextCell
+                        value={optionName}
+                        onChange={e => {
+                          setOptionName(e.target, skillName, currentSkills, setCurrentSkills);
+                        }}
+                      />
+                    </td>
                     <td>{level}</td>
                   </tr>,
                 );

--- a/src/components/SingleSkillTypeTable.tsx
+++ b/src/components/SingleSkillTypeTable.tsx
@@ -29,6 +29,9 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     setSkills: (currentSkills: SkillsType) => void,
     skillName: string,
   ) => {
+    if (skillName == 'Martial Arts') {
+      return;
+    }
     const newSkills = { ...currentSkills };
 
     // This isn't going to work anymore when you can change the names of the options.
@@ -36,7 +39,7 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     let n = 1;
     let success = false;
 
-    while (success == false && n <= MAX_SKILL_POINTS && skillName != 'Martial Arts') {
+    while (success == false && n <= MAX_SKILL_POINTS) {
       const optionExists =
         newSkills[skillName]['options'][n]['name'] && newSkills[skillName]['options'][n]['name'] != '';
 
@@ -62,6 +65,10 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     currentSkills: SkillsType,
     setCurrentSkills: (skills: SkillsType) => void,
   ) => {
+    if (skillName == 'Martial Arts') {
+      return;
+    }
+
     const newName = target.value;
     const newSkills = { ...currentSkills };
 
@@ -134,6 +141,7 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
                   <tr className={style}>
                     <td>
                       <SimpleEditableTextCell
+                        className="bg-transparent"
                         value={optionName}
                         onChange={e => {
                           setOptionName(e.target, skillName, optionID, currentSkills, setCurrentSkills);

--- a/src/components/SingleSkillTypeTable.tsx
+++ b/src/components/SingleSkillTypeTable.tsx
@@ -34,7 +34,6 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     }
     const newSkills = { ...currentSkills };
 
-    // This isn't going to work anymore when you can change the names of the options.
     const MAX_SKILL_POINTS = 6;
     let n = 1;
     let success = false;
@@ -54,10 +53,6 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
     }
   };
 
-  // If you activate this, it moves the box to the bottom of the list of options.
-  // It's activated every time you press a key so you basically can't change anything unless it's already at the bottom of the list
-  // need to use onBlur or onKeyDown instead of onChange? But then how does the text actually change?
-  // Change the data structure so that the options have a numerical indetifier to use as a key, and a name property?
   const setOptionName = (
     target: any,
     skillName: string,
@@ -90,10 +85,7 @@ const SingleSkillTypeTable = ({ tableSkillType, remainingPoints, setRemainingPoi
         </thead>
         <tbody>
           {skillsList.map(skill => {
-            // need to deal with skills with options here
-            // one extra row per option
-            // need to be able to change options so cultural origin one can be set
-            // should be able to add/remove? For start can just have the max number of option rows and leave them 0
+            // need to handle cultural origin rows. At least 4 points over 1-4 languages.
             const skillName = skill['name'];
             const pointCost = skill['x2'] ? 2 : 1;
             const skillLevel = currentSkills[skillName]['level'];

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -72,5 +72,3 @@ const Skills = () => {
 };
 
 export default Skills;
-// The following Skills must be at least Level 2: Athletics, Brawling, Concentration, Conversation, Education, Evasion, First Aid, Human Perception, Language (Streetslang), Local Expert (Your Home), Perception, Persuasion, and Stealth.
-// Don't forget the 4 Levels of Language you get free based on the Cultural Origin section of you Lifepath (See The Personals).

--- a/src/data/defaultSkills.json
+++ b/src/data/defaultSkills.json
@@ -103,11 +103,30 @@
     "level": 2,
     "has_options": true,
     "options": {
-      "Streetslang": 2,
-      "(Cultural Origin Option 1)": 1,
-      "(Cultural Origin Option 2)": 1,
-      "(Cultural Origin Option 3)": 1,
-      "(Cultural Origin Option 4)": 1
+      "1": {
+        "name": "Streetslang",
+        "level": 2
+      },
+      "2": {
+        "name": "(Cultural Origin Option 1)",
+        "level": 0
+      },
+      "3": {
+        "name": "(Cultural Origin Option 2)",
+        "level": 0
+      },
+      "4": {
+        "name": "(Cultural Origin Option 3)",
+        "level": 0
+      },
+      "5": {
+        "name": "(Cultural Origin Option 4)",
+        "level": 0
+      },
+      "6": {
+        "name": "",
+        "level": 0
+      }
     }
   },
   "Library Search": {
@@ -118,7 +137,30 @@
     "level": 2,
     "has_options": true,
     "options": {
-      "Your Home": 2
+      "1": {
+        "name": "Your Home",
+        "level": 2
+      },
+      "2": {
+        "name": "",
+        "level": 0
+      },
+      "3": {
+        "name": "",
+        "level": 0
+      },
+      "4": {
+        "name": "",
+        "level": 0
+      },
+      "5": {
+        "name": "",
+        "level": 0
+      },
+      "6": {
+        "name": "",
+        "level": 0
+      }
     }
   },
   "Science": {
@@ -144,7 +186,24 @@
   "Martial Arts": {
     "level": 0,
     "has_options": true,
-    "options": {}
+    "options": {
+      "1": {
+        "name": "Aikido",
+        "level": 0
+      },
+      "2": {
+        "name": "Karate",
+        "level": 0
+      },
+      "3": {
+        "name": "Judo",
+        "level": 0
+      },
+      "4": {
+        "name": "Taekwondo",
+        "level": 0
+      }
+    }
   },
   "Melee Weapon": {
     "level": 0,
@@ -157,7 +216,32 @@
   "Play Instrument": {
     "level": 0,
     "has_options": true,
-    "options": {}
+    "options": {
+      "1": {
+        "name": "",
+        "level": 0
+      },
+      "2": {
+        "name": "",
+        "level": 0
+      },
+      "3": {
+        "name": "",
+        "level": 0
+      },
+      "4": {
+        "name": "",
+        "level": 0
+      },
+      "5": {
+        "name": "",
+        "level": 0
+      },
+      "6": {
+        "name": "",
+        "level": 0
+      }
+    }
   },
   "Archery": {
     "level": 0,

--- a/src/style/cells.css
+++ b/src/style/cells.css
@@ -31,8 +31,3 @@
 .dropdown:hover .dropbtn {
   background-color: var(--light-red-bg-1);
 }
-
-/* SIMPLE EDITABLE TEXT CELL */
-.simpleEditableTextCell {
-  padding: 12px;
-}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,6 +4,6 @@ export type Effects = Record<string, Effect>;
 export type ModalDisplays = Record<string, string>;
 
 export type Skill = Record<string, any>;
-export type Skills = Record<string, Skill>;
+export type SkillsType = Record<string, Skill>;
 
 export type Stats = Record<string, number>;

--- a/src/utils/IncrementDecrementSkill.tsx
+++ b/src/utils/IncrementDecrementSkill.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 
 import { SkillsContext } from '../App';
 import skillsJson from '../data/skills.json';
-import { Skills } from '../types/types';
+import { SkillsType } from '../types/types';
 import { incrementAnyNumericalState } from './commonMethods';
 
 type IncrementDecrementSkillProps = {
@@ -18,8 +18,8 @@ const IncrementDecrementSkill = ({ skillName, remainingPoints, setRemainingPoint
   const cost = skillStats[0]['x2'] ? 2 : 1;
 
   const increment = (
-    currentSkills: Skills,
-    setSkills: (currentSkills: Skills) => void,
+    currentSkills: SkillsType,
+    setSkills: (currentSkills: SkillsType) => void,
     skillName: string,
     remainingPoints: number,
     setRemainingPoints: (newPoints: number) => void,
@@ -37,8 +37,8 @@ const IncrementDecrementSkill = ({ skillName, remainingPoints, setRemainingPoint
   };
 
   const decrement = (
-    currentSkills: Skills,
-    setSkills: (currentSkills: Skills) => void,
+    currentSkills: SkillsType,
+    setSkills: (currentSkills: SkillsType) => void,
     skillName: string,
     remainingPoints: number,
     setRemainingPoints: (newPoints: number) => void,

--- a/src/utils/SimpleEditableTextCell.tsx
+++ b/src/utils/SimpleEditableTextCell.tsx
@@ -2,14 +2,22 @@ import '../style/cells.css';
 
 type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-export const SimpleEditableTextCell = ({ placeholder, value, onChange, onBlur, disabled }: TextInputProps) => {
+export const SimpleEditableTextCell = ({
+  placeholder,
+  value,
+  onChange,
+  onBlur,
+  disabled,
+  className,
+}: TextInputProps) => {
+  const styles = 'px-2 ' + className;
   return (
     <input
       value={value}
       onChange={onChange}
       onBlur={onBlur}
       type="text"
-      className={'rounded border px-2'}
+      className={styles}
       placeholder={placeholder}
       disabled={disabled}
     />

--- a/src/utils/SimpleEditableTextCell.tsx
+++ b/src/utils/SimpleEditableTextCell.tsx
@@ -5,7 +5,6 @@ type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 export const SimpleEditableTextCell = ({ placeholder, value, onChange, onBlur, disabled }: TextInputProps) => {
   return (
     <input
-      data-originalValue={value}
       value={value}
       onChange={onChange}
       onBlur={onBlur}

--- a/src/utils/SimpleEditableTextCell.tsx
+++ b/src/utils/SimpleEditableTextCell.tsx
@@ -2,11 +2,13 @@ import '../style/cells.css';
 
 type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-export const SimpleEditableTextCell = ({ placeholder, value, onChange, disabled }: TextInputProps) => {
+export const SimpleEditableTextCell = ({ placeholder, value, onChange, onBlur, disabled }: TextInputProps) => {
   return (
     <input
+      data-originalValue={value}
       value={value}
       onChange={onChange}
+      onBlur={onBlur}
       type="text"
       className={'rounded border px-2'}
       placeholder={placeholder}

--- a/src/utils/SimpleEditableTextCell.tsx
+++ b/src/utils/SimpleEditableTextCell.tsx
@@ -2,20 +2,12 @@ import '../style/cells.css';
 
 type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-export const SimpleEditableTextCell = ({
-  placeholder,
-  value,
-  onChange,
-  onBlur,
-  disabled,
-  className,
-}: TextInputProps) => {
+export const SimpleEditableTextCell = ({ placeholder, value, onChange, disabled, className }: TextInputProps) => {
   const styles = 'px-2 ' + className;
   return (
     <input
       value={value}
       onChange={onChange}
-      onBlur={onBlur}
       type="text"
       className={styles}
       placeholder={placeholder}

--- a/src/utils/commonMethods.tsx
+++ b/src/utils/commonMethods.tsx
@@ -26,6 +26,25 @@ const decrementAnyNumericalState = (currentState: number, setState: (newState: n
   return success;
 };
 
+const incrementHumanity = (
+  humanity: number,
+  setHumanity: (newHumanity: number) => void,
+  stats: Stats,
+  setStats: (stats: Stats) => void,
+) => {
+  let success = false;
+  const startHumanityModulusTen = humanity % 10;
+
+  if (startHumanityModulusTen == 9) {
+    let newStats = { ...stats };
+    newStats['EMP'] += 1;
+    setStats(newStats);
+  }
+  setHumanity(humanity + 1);
+  success = true;
+  return success;
+};
+
 const decrementHumanity = (
   humanity: number,
   setHumanity: (newHumanity: number) => void,
@@ -36,7 +55,6 @@ const decrementHumanity = (
   const startHumanityModulusTen = humanity % 10;
 
   if (humanity > 0 && startHumanityModulusTen == 0) {
-    // subtract one from emp
     let newStats = { ...stats };
     newStats['EMP'] -= 1;
     setStats(newStats);
@@ -104,6 +122,7 @@ const updateHumanity = (setHumanity: (newHumanity: number) => void, newStats: St
 export {
   decrementAnyNumericalState,
   incrementAnyNumericalState,
+  incrementHumanity,
   decrementHumanity,
   calculateHP,
   calculateHPMax,

--- a/src/utils/commonMethods.tsx
+++ b/src/utils/commonMethods.tsx
@@ -26,46 +26,6 @@ const decrementAnyNumericalState = (currentState: number, setState: (newState: n
   return success;
 };
 
-const incrementHumanity = (
-  humanity: number,
-  setHumanity: (newHumanity: number) => void,
-  stats: Stats,
-  setStats: (stats: Stats) => void,
-) => {
-  let success = false;
-  const startHumanityModulusTen = humanity % 10;
-
-  if (startHumanityModulusTen == 9) {
-    let newStats = { ...stats };
-    newStats['EMP'] += 1;
-    setStats(newStats);
-  }
-  setHumanity(humanity + 1);
-  success = true;
-  return success;
-};
-
-const decrementHumanity = (
-  humanity: number,
-  setHumanity: (newHumanity: number) => void,
-  stats: Stats,
-  setStats: (stats: Stats) => void,
-) => {
-  let success = false;
-  const startHumanityModulusTen = humanity % 10;
-
-  if (humanity > 0 && startHumanityModulusTen == 0) {
-    let newStats = { ...stats };
-    newStats['EMP'] -= 1;
-    setStats(newStats);
-  }
-  if (humanity > 0) {
-    setHumanity(humanity - 1);
-    success = true;
-  }
-  return success;
-};
-
 // CALCULATIONS
 const calculateHPMax = (stats: Stats) => {
   const bodyWillAverage = Math.ceil((stats['BODY'] + stats['WILL']) / 2);
@@ -122,8 +82,6 @@ const updateHumanity = (setHumanity: (newHumanity: number) => void, newStats: St
 export {
   decrementAnyNumericalState,
   incrementAnyNumericalState,
-  incrementHumanity,
-  decrementHumanity,
   calculateHP,
   calculateHPMax,
   calculateHumanity,


### PR DESCRIPTION
Allow change of option names for skills. 
Skill number is limited to 6, except for martial arts which has a  set list of 4 possible options.

## Changed
`src/components/Profile.tsx`
- move styling for SimpleEditableTextBox up one layer
- Add adjuster buttons for humanity

`src/components/SingleSkillTypeTable.tsx`
- rename Skills to SkillsType to avoid conflicts with Skills component
- rewrite addNewOption() method
- create setOptionName() method 
- rewrite forEach to map for new data structure of options

`src/data/defaultSkills.json`
- options are now held in records, not arrays
- Each option always has the full number of option, but the names can be blank

`src/style/cells.css`
- remove rules for .simpleEditableTextCell

`src/types/types.ts`
- rename Skills to SkillsType

`src/utils/IncrementDecrementSkill.tsx`
- rename Skills to SkillsType

`src/utils/SimpleEditableTextCell.tsx`
- add className props to apply different styling to different use cases

`src/utils/commonMethods.tsx`
- create incrementHumanity() method to increase EMP if humanity goes up a 10s place

  
